### PR TITLE
Make Context.create public again

### DIFF
--- a/lib/em-zeromq/context.rb
+++ b/lib/em-zeromq/context.rb
@@ -19,11 +19,15 @@ module EventMachine
       end
 
       def bind(socket_type, address, handler = nil, opts = {})
-        create(socket_type, :bind, address, handler, opts)
+        build(socket_type, :bind, address, handler, opts)
       end
 
       def connect(socket_type, address, handler = nil, opts = {})
-        create(socket_type, :connect, address, handler, opts)
+        build(socket_type, :connect, address, handler, opts)
+      end
+
+      def create(socket_type, bind_or_connect, address, handler, opts = {})
+        build(socket_type, bind_or_connect, address, handler, opts)
       end
       
     private
@@ -35,7 +39,7 @@ module EventMachine
         end
       end
       
-      def create(socket_type, bind_or_connect, address, handler, opts = {})
+      def build(socket_type, bind_or_connect, address, handler, opts = {})
         socket_type = find_type(socket_type)
         socket = @context.socket(socket_type)
         


### PR DESCRIPTION
Switching create to a private method makes a slight mess of DripDrop's ability to just pass in the :bind or :connect to the context to create the "socket". Small change pushes create back up to public and renames the private method to build (best I could come up with).
