### PR TITLE
Register read write

### DIFF
--- a/lib/em-zeromq/connection.rb
+++ b/lib/em-zeromq/connection.rb
@@ -78,7 +78,6 @@ module EventMachine
         end
       end
       
-      
       def setsockopt(opt, value)
         @socket.setsockopt(opt, value)
       end
@@ -88,6 +87,22 @@ module EventMachine
         detach_and_close
       end
       
+      # Make this socket available for reads
+      def register_readable
+        # Since ZMQ is event triggered I think this is necessary
+        if readable?
+          notify_readable
+        end
+        # Subscribe to EM read notifications
+        self.notify_readable = true
+      end
+
+      # Trigger on_readable when socket is readable
+      def register_writable
+        # Subscribe to EM write notifications
+        self.notify_writable = true
+      end
+
     private
       # internal methods
       def readable?
@@ -131,7 +146,7 @@ module EventMachine
       def notify_writable
         return unless writable?
         
-        # one a writable event is successfullt received the socket
+        # one a writable event is successfully received the socket
         # should be accepting messages again so stop triggering
         # write events
         self.notify_writable = false

--- a/lib/em-zeromq/context.rb
+++ b/lib/em-zeromq/context.rb
@@ -48,11 +48,11 @@ module EventMachine
         conn = EM.watch(socket.getsockopt(ZMQ::FD), EventMachine::ZeroMQ::Connection, socket, socket_type, address, handler)
 
         if READABLES.include?(socket_type)
-          conn.notify_readable = true
+          conn.register_readable
         end
         
         if WRITABLES.include?(socket_type)
-          conn.notify_writable = true
+          conn.register_writable
         end
 
         conn

--- a/spec/xreq_xrep_spec.rb
+++ b/spec/xreq_xrep_spec.rb
@@ -10,6 +10,7 @@ describe EventMachine::ZeroMQ do
       @received += messages
     end
   end
+
   class EMTestXREPHandler
     attr_reader :received
     def initialize(&block)


### PR DESCRIPTION
I would like to put back register_readable and register_writable as I was hitting a race condition where the connection for an xreq socket was not getting the response back from an xrep socket because the notify_readable = true call was occuring after EM had signaled a read was available for the socket. That meant I wasn't even checking for the response because EM won't resignal after it's told us something is there. Going back to register_readable allows for the readable? check and thus it catches the quick event from EM and the xreq socket works correctly again.

I added back register_writable just to have a consistent interface.
