### PR TITLE
Return the value from send_string when send_msg returns.

### DIFF
--- a/lib/em-zeromq/connection.rb
+++ b/lib/em-zeromq/connection.rb
@@ -69,7 +69,6 @@ module EventMachine
           # all the previous parts were queued, send
           # the last one
           @socket.send_string(parts[-1], ZMQ::NOBLOCK)
-          true
         else
           # error while sending the previous parts
           # register the socket for writability


### PR DESCRIPTION
Since send_msg is setting NOBLOCK on send_string the only way the
calling program knows if the message was sent or not is to check the
return value but this was always being set to true thus masking the
correct value.
