### PR TITLE
FFI rzmq 1.0 has been released. we should use it.

### DIFF
--- a/em-zeromq.gemspec
+++ b/em-zeromq.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'eventmachine', '>= 1.0.0'
   s.add_dependency 'ffi', '>= 1.0.0'
-  s.add_dependency 'ffi-rzmq', '>= 1.0.0'
+  s.add_dependency 'ffi-rzmq', '~> 1.0.0'
 
   s.add_development_dependency 'rspec', '>= 2.5.0'
   s.add_development_dependency 'simplecov'

--- a/em-zeromq.gemspec
+++ b/em-zeromq.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'eventmachine', '>= 1.0.0'
   s.add_dependency 'ffi', '>= 1.0.0'
-  s.add_dependency 'ffi-rzmq', '= 0.9.7'
+  s.add_dependency 'ffi-rzmq', '>= 1.0.0'
 
   s.add_development_dependency 'rspec', '>= 2.5.0'
   s.add_development_dependency 'simplecov'

--- a/lib/em-zeromq/version.rb
+++ b/lib/em-zeromq/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module EmZeromq
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
I have the need to use ffi-rzmq >= 1.0.

I have updated the dependencies of em-zeromq.

Tests pass and I am running my apps with 

Can you please release a new version of the gem?

I have also relaxed the dependencies.

It's really cumbersome to build a new gem every time a new ffi-rzmq gem is released.

Maybe I overshot the mark with '>= 1.0.0' and it should be '~> 1.0.0'.

But fixing the exact version is really horrible.
